### PR TITLE
Add clusterrole etc to fix sidecar's permission and minor fixes

### DIFF
--- a/charts/plutono/templates/_pod.tpl
+++ b/charts/plutono/templates/_pod.tpl
@@ -427,6 +427,11 @@ containers:
       - name: "{{ $key }}"
         value: "{{ $value }}"
       {{- end }}
+      {{- range $key, $value := .Values.sidecar.datasources.envValueFrom }}
+      - name: {{ $key | quote }}
+        valueFrom:
+          {{- tpl (toYaml $value) $ | nindent 10 }}
+      {{- end }}
       {{- if .Values.sidecar.dashboards.ignoreAlreadyProcessed }}
       - name: IGNORE_ALREADY_PROCESSED
         value: "true"
@@ -1257,10 +1262,13 @@ volumes:
       {{ toYaml .hostPath | nindent 6 }}
     {{- else if .csi }}
     csi:
-      {{- toYaml .data | nindent 6 }}
+      {{- toYaml .csi | nindent 6 }}
     {{- else if .configMap }}
     configMap:
       {{- toYaml .configMap | nindent 6 }}
+    {{- else if .emptyDir }}
+    emptyDir:
+      {{- toYaml .emptyDir | nindent 6 }}
     {{- else }}
     emptyDir: {}
     {{- end }}

--- a/charts/plutono/templates/clusterrole.yaml
+++ b/charts/plutono/templates/clusterrole.yaml
@@ -1,0 +1,25 @@
+{{- if and .Values.rbac.create (or (not .Values.rbac.namespaced) .Values.rbac.extraClusterRoleRules) (not .Values.rbac.useExistingClusterRole) }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "plutono.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "plutono.fullname" . }}-clusterrole
+{{- if or .Values.sidecar.dashboards.enabled .Values.rbac.extraClusterRoleRules .Values.sidecar.datasources.enabled .Values.sidecar.plugins.enabled .Values.sidecar.alerts.enabled }}
+rules:
+  {{- if or .Values.sidecar.dashboards.enabled .Values.sidecar.datasources.enabled .Values.sidecar.plugins.enabled .Values.sidecar.alerts.enabled }}
+  - apiGroups: [""] # "" indicates the core API group
+    resources: ["configmaps", "secrets"]
+    verbs: ["get", "watch", "list"]
+  {{- end}}
+  {{- with .Values.rbac.extraClusterRoleRules }}
+  {{- toYaml . | nindent 2 }}
+  {{- end}}
+{{- else }}
+rules: []
+{{- end}}
+{{- end}}

--- a/charts/plutono/templates/clusterrolebinding.yaml
+++ b/charts/plutono/templates/clusterrolebinding.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.rbac.create (or (not .Values.rbac.namespaced) .Values.rbac.extraClusterRoleRules) }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "plutono.fullname" . }}-clusterrolebinding
+  labels:
+    {{- include "plutono.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "plutono.serviceAccountName" . }}
+    namespace: {{ include "plutono.namespace" . }}
+roleRef:
+  kind: ClusterRole
+  {{- if .Values.rbac.useExistingClusterRole }}
+  name: {{ .Values.rbac.useExistingClusterRole }}
+  {{- else }}
+  name: {{ include "plutono.fullname" . }}-clusterrole
+  {{- end }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/plutono/templates/configSecret.yaml
+++ b/charts/plutono/templates/configSecret.yaml
@@ -25,13 +25,13 @@ stringData:
 {{- range $key, $value := .Values.datasources }}
 {{- if (hasKey $value "secret") }}
 {{- $key | nindent 2 }}: |
-  {{- tpl (toYaml $value | nindent 4) $root }}
+  {{- tpl (toYaml $value.secret | nindent 4) $root }}
 {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.notifiers }}
-{{- if (hasKey $value "secret") }}
+{{- if (hasKey $value "secret") }}xs
 {{- $key | nindent 2 }}: |
-  {{- tpl (toYaml $value | nindent 4) $root }}
+  {{- tpl (toYaml $value.secret | nindent 4) $root }}
 {{- end }}
 {{- end }}
 {{- range $key, $value := .Values.alerting }}


### PR DESCRIPTION
We wanted to use sidecar setting and let the sidecar container uses the configmaps to load dashboards.
This failed and the sidecar container's log showed this error:

`{"time": "2024-02-19T12:30:22.383809+00:00", "taskName": null, "msg": "ApiException when calling kubernetes: (403)\nReason: Forbidden\nHTTP response headers: HTTPHeaderDict({'Audit-Id': '3c46264a-79bd-4aa0-bc7e-d17c03574d9d', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'X-Kubernetes-Pf-Flowschema-Uid': '3b9d5aaa-db7a-4606-9258-e8e5165e1590', 'X-Kubernetes-Pf-Prioritylevel-Uid': 'b86d9403-ddc2-48ed-93ce-d8d1663c19cf', 'Date': 'Mon, 19 Feb 2024 12:30:22 GMT', 'Content-Length': '314'})\nHTTP response body: b'{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"configmaps is forbidden: User \\\\\"system:serviceaccount:monitoring3:test-plutono\\\\\" cannot watch resource \\\\\"configmaps\\\\\" in API group \\\\\"\\\\\" in the namespace \\\\\"monitoring3\\\\\"\",\"reason\":\"Forbidden\",\"details\":{\"kind\":\"configmaps\"},\"code\":403}\\n'\n\n", "level": "ERROR"}
`

This PR adds the clusterrole and clusterrolebinding resources to the chart template so that the sidecar container can inject the dashboards. In addition, it also includes some minor changes to other files.