### PR TITLE
Rename ENV variables to PL_ prefix

### DIFF
--- a/charts/plutono/templates/_pod.tpl
+++ b/charts/plutono/templates/_pod.tpl
@@ -356,14 +356,14 @@ containers:
       - name: SCRIPT
         value: {{ quote . }}
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_USER) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
         valueFrom:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "plutono.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_PASSWORD) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
         valueFrom:
           secretKeyRef:
@@ -468,14 +468,14 @@ containers:
         value: "{{ . }}"
       {{- end }}
       {{- if not .Values.sidecar.dashboards.skipReload }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_USER) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
         valueFrom:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "plutono.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_PASSWORD) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
         valueFrom:
           secretKeyRef:
@@ -574,14 +574,14 @@ containers:
       - name: SCRIPT
         value: "{{ .Values.sidecar.datasources.script }}"
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_USER) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
         valueFrom:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "plutono.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_PASSWORD) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
         valueFrom:
           secretKeyRef:
@@ -678,14 +678,14 @@ containers:
       - name: SCRIPT
         value: "{{ .Values.sidecar.notifiers.script }}"
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_USER) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
         valueFrom:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "plutono.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_PASSWORD) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
         valueFrom:
           secretKeyRef:
@@ -782,14 +782,14 @@ containers:
       - name: SKIP_TLS_VERIFY
         value: "{{ . }}"
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_USER) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_USERNAME
         valueFrom:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "plutono.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_PASSWORD) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
       - name: REQ_PASSWORD
         valueFrom:
           secretKeyRef:
@@ -1002,52 +1002,52 @@ containers:
         valueFrom:
           fieldRef:
             fieldPath: status.podIP
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_USER) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
-      - name: GF_SECURITY_ADMIN_USER
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_USER) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: PL_SECURITY_ADMIN_USER
         valueFrom:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "plutono.fullname" .) }}
             key: {{ .Values.admin.userKey | default "admin-user" }}
       {{- end }}
-      {{- if and (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
-      - name: GF_SECURITY_ADMIN_PASSWORD
+      {{- if and (not .Values.env.PL_SECURITY_ADMIN_PASSWORD) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+      - name: PL_SECURITY_ADMIN_PASSWORD
         valueFrom:
           secretKeyRef:
             name: {{ (tpl .Values.admin.existingSecret .) | default (include "plutono.fullname" .) }}
             key: {{ .Values.admin.passwordKey | default "admin-password" }}
       {{- end }}
       {{- if .Values.plugins }}
-      - name: GF_INSTALL_PLUGINS
+      - name: PL_INSTALL_PLUGINS
         valueFrom:
           configMapKeyRef:
             name: {{ include "plutono.fullname" . }}
             key: plugins
       {{- end }}
       {{- if .Values.smtp.existingSecret }}
-      - name: GF_SMTP_USER
+      - name: PL_SMTP_USER
         valueFrom:
           secretKeyRef:
             name: {{ .Values.smtp.existingSecret }}
             key: {{ .Values.smtp.userKey | default "user" }}
-      - name: GF_SMTP_PASSWORD
+      - name: PL_SMTP_PASSWORD
         valueFrom:
           secretKeyRef:
             name: {{ .Values.smtp.existingSecret }}
             key: {{ .Values.smtp.passwordKey | default "password" }}
       {{- end }}
       {{- if .Values.imageRenderer.enabled }}
-      - name: GF_RENDERING_SERVER_URL
+      - name: PL_RENDERING_SERVER_URL
         value: http://{{ include "plutono.fullname" . }}-image-renderer.{{ include "plutono.namespace" . }}:{{ .Values.imageRenderer.service.port }}/render
-      - name: GF_RENDERING_CALLBACK_URL
+      - name: PL_RENDERING_CALLBACK_URL
         value: {{ .Values.imageRenderer.plutonoProtocol }}://{{ include "plutono.fullname" . }}.{{ include "plutono.namespace" . }}:{{ .Values.service.port }}/{{ .Values.imageRenderer.plutonoSubPath }}
       {{- end }}
-      - name: GF_PATHS_DATA
+      - name: PL_PATHS_DATA
         value: {{ (get .Values "plutono.ini").paths.data }}
-      - name: GF_PATHS_LOGS
+      - name: PL_PATHS_LOGS
         value: {{ (get .Values "plutono.ini").paths.logs }}
-      - name: GF_PATHS_PLUGINS
+      - name: PL_PATHS_PLUGINS
         value: {{ (get .Values "plutono.ini").paths.plugins }}
-      - name: GF_PATHS_PROVISIONING
+      - name: PL_PATHS_PROVISIONING
         value: {{ (get .Values "plutono.ini").paths.provisioning }}
       {{- range $key, $value := .Values.envValueFrom }}
       - name: {{ $key | quote }}

--- a/charts/plutono/templates/deployment.yaml
+++ b/charts/plutono/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/dashboards-json-config: {{ include (print $.Template.BasePath "/dashboards-json-configmap.yaml") . | sha256sum }}
         checksum/sc-dashboard-provider-config: {{ include (print $.Template.BasePath "/configmap-dashboard-provider.yaml") . | sha256sum }}
-        {{- if and (or (and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD)) (and .Values.ldap.enabled (not .Values.ldap.existingSecret))) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
+        {{- if and (or (and (not .Values.admin.existingSecret) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD)) (and .Values.ldap.enabled (not .Values.ldap.existingSecret))) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.envRenderSecret }}

--- a/charts/plutono/templates/secret.yaml
+++ b/charts/plutono/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if or (and (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION)) (and .Values.ldap.enabled (not .Values.ldap.existingSecret)) }}
+{{- if or (and (not .Values.admin.existingSecret) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD) (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION)) (and .Values.ldap.enabled (not .Values.ldap.existingSecret)) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -12,7 +12,7 @@ metadata:
   {{- end }}
 type: Opaque
 data:
-  {{- if and (not .Values.env.GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) (not .Values.admin.existingSecret) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.GF_SECURITY_ADMIN_PASSWORD) }}
+  {{- if and (not .Values.env.PL_SECURITY_DISABLE_INITIAL_ADMIN_CREATION) (not .Values.admin.existingSecret) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD__FILE) (not .Values.env.PL_SECURITY_ADMIN_PASSWORD) }}
   admin-user: {{ .Values.adminUser | b64enc | quote }}
   {{- if .Values.adminPassword }}
   admin-password: {{ .Values.adminPassword | b64enc | quote }}


### PR DESCRIPTION
We tried to use the `adminPassword` value to set a custom `admin-password`, for example, but that didn’t work. After a bit of digging it turned out, that some of the templates were using `GF_` prefix ENV variables, while it is described in described in https://github.com/credativ/plutono#about-this-fork that they have been renamed to `PL_`.

This change uses the correct prefix for ENV variables (as described in https://github.com/credativ/plutono#about-this-fork). Setting `adminPassword` in values now works, for example.