### PR TITLE
Fix chart yaml

### DIFF
--- a/charts/plutono/Chart.yaml
+++ b/charts/plutono/Chart.yaml
@@ -8,7 +8,7 @@ sources:
 maintainers:
   - name: credativ
 version: 0.1.0
-appVersion: 0.1.0
+appVersion: main
 
 
 


### PR DESCRIPTION
Address the following image pull error:
```
Failed to pull image "ghcr.io/credativ/plutono:0.1.0": rpc error: code = NotFound desc = failed to pull and unpack image "ghcr.io/credativ/plutono:0.1.0": failed to resolve reference "ghcr.io/credativ/plutono:0.1.0": ghcr.io/credativ/plutono:0.1.0: not found
Source
```